### PR TITLE
Performance improvements when querying large areas

### DIFF
--- a/gaialib2/.gitignore
+++ b/gaialib2/.gitignore
@@ -1,0 +1,2 @@
+gaia2read
+*.o

--- a/gaialib2/Makefile
+++ b/gaialib2/Makefile
@@ -15,7 +15,7 @@ BINDIR          = ../../bin
 CC              = gcc
 MAKE            = make
 
-CFLAGS   = -W -Wall -ansi -pedantic -std=c99 -g
+CFLAGS   = -W -Wall -pedantic -std=c99 -g
 
 ###############################################################################
 

--- a/gaialib2/Makefile
+++ b/gaialib2/Makefile
@@ -1,50 +1,88 @@
+###############################################################################
+# program name and version
+
+PROGNAME        = gaia2read
+PROGVERSION     = 1.0
+
+
+###############################################################################
+# deployment directory
+BINDIR          = ../../bin
+
+###############################################################################
+# compiler
+
+CC              = gcc
+MAKE            = make
+
+CFLAGS   = -W -Wall -ansi -pedantic -std=c99 -g
+
+###############################################################################
+
+# targets
+
+###############################################################################
+# default: target program (release)
+
+.PHONY: all
+
+all: $(PROGNAME)
+
+###############################################################################
+# deploy target
+
+.PHONY: install
+
+install: all
+	@echo "installing $(PROGNAME) to $(BINDIR)"
+	@cp -f $(PROGNAME) $(BINDIR)
+
+.PHONY: clean
+
+clean:
+	rm -f *.o $(PROGNAME)
+
 gaia2read: gaia2read.o gaia2ret.o gaia2cat.o gaiastar.o astromath.o astrio.o astrometry.o mmath.o myargs.o pmotion.o point.o sllist.o utils.o gaiaPrint.o
-	gcc -O -Wall -W -pedantic -std=c99 -o gaia2read gaia2read.o gaia2ret.o gaia2cat.o gaiastar.o astromath.o astrio.o astrometry.o mmath.o myargs.o pmotion.o point.o sllist.o utils.o gaiaPrint.o -lm
+	$(CC) $(CFLAGS) -o gaia2read gaia2read.o gaia2ret.o gaia2cat.o gaiastar.o astromath.o astrio.o astrometry.o mmath.o myargs.o pmotion.o point.o sllist.o utils.o gaiaPrint.o -lm
 
 gaia2read.o: gaia2read.c gaia2ret.h myargs.h astrio.h astrometry.h utils.h gaiaPrint.h
-	gcc -O -Wall -W -pedantic -ansi -std=c99 -c gaia2read.c
+	$(CC) $(CFLAGS) -c gaia2read.c
 
 gaia2ret.o: gaia2ret.c gaia2ret.h gaia2cat.h astrometry.h mmath.h utils.h gaia2idsort.h gaiastar.h sllist.h astromath.h pmotion.h
-	gcc -O -Wall -W -pedantic -ansi -std=c99 -c gaia2ret.c
+	$(CC) $(CFLAGS) -c gaia2ret.c
 
 gaia2cat.o: gaia2cat.c gaiastar.h sllist.h gaia2cat.h gaia2ret.h utils.h
-	gcc -O -Wall -W -pedantic -ansi -std=c99 -c gaia2cat.c
+	$(CC) $(CFLAGS) -c gaia2cat.c
 
 gaiastar.o: gaiastar.c gaiastar.h pmotion.h
-	gcc -O -Wall -W -pedantic -ansi -std=c99 -c gaiastar.c
+	$(CC) $(CFLAGS) -c gaiastar.c
 
 gaiaPrint.o: gaiaPrint.c gaiaPrint.h gaiastar.h gaia2ret.h
-	gcc -O -Wall -W -pedantic -ansi -std=c99 -c gaiaPrint.c
+	$(CC) $(CFLAGS) -c gaiaPrint.c
 
 astromath.o: astromath.c astromath.h mmath.h
-	gcc -O -Wall -W -pedantic -ansi -std=c99 -c astromath.c
+	$(CC) $(CFLAGS) -c astromath.c
 
 astrio.o: astrio.c astrio.h astromath.h mmath.h
-	gcc -O -Wall -W -pedantic -ansi -std=c99 -c astrio.c
+	$(CC) $(CFLAGS) -c astrio.c
 
 astrometry.o: astrometry.c astrometry.h astromath.h mmath.c
-	gcc -O -Wall -W -pedantic -ansi -std=c99 -c astrometry.c
+	$(CC) $(CFLAGS) -c astrometry.c
 
 mmath.o: mmath.c mmath.h
-	gcc -O -Wall -W -pedantic -ansi -std=c99 -c mmath.c
+	$(CC) $(CFLAGS) -c mmath.c
 
 myargs.o: myargs.c myargs.h utils.h
-	gcc -O -Wall -W -pedantic -ansi -std=c99 -c myargs.c
+	$(CC) $(CFLAGS) -c myargs.c
 
 pmotion.o: pmotion.c pmotion.h astromath.h
-	gcc -O -Wall -W -pedantic -ansi -std=c99 -c pmotion.c
+	$(CC) $(CFLAGS) -c pmotion.c
 
 point.o: point.c point.h astrometry.h mmath.h
-	gcc -O -Wall -W -pedantic -ansi -std=c99 -c point.c
+	$(CC) $(CFLAGS) -c point.c
 
 sllist.o: sllist.c sllist.h
-	gcc -O -Wall -W -pedantic -ansi -std=c99 -c sllist.c
+	$(CC) $(CFLAGS) -c sllist.c
 
 utils.o: utils.c utils.h
-	gcc -O -Wall -W -pedantic -ansi -std=c99 -c utils.c
-
-
-
-
-
-
+	$(CC) $(CFLAGS) -c utils.c

--- a/gaialib2/gaia2cat.c
+++ b/gaialib2/gaia2cat.c
@@ -1,3 +1,5 @@
+#define _GNU_SOURCE
+
 #include <string.h>
 #include <dirent.h>
 #include <stdio.h>
@@ -197,7 +199,8 @@ int binarySearch(FILE *zFile, int raZone, double ra, bool minormax)//true for mi
   return rzIndex1+(middleStar)*STARSIZE;
 }
 
-int posCount(double raMin, double raMax, double decMin, double decMax, testfunc tester,double ra,double dec, double frame_size, const double *epoch)
+int posCount(double raMin, double raMax, double decMin, double decMax, testfunc tester,double ra,double dec, double frame_size,
+        const double *epoch, const maglims* maglim)
 {
   int count = 0;
 
@@ -266,9 +269,9 @@ int posCount(double raMin, double raMax, double decMin, double decMax, testfunc 
                 continue;
               id = newStar.source_id;
 
-              if((*tester)(&newStar,ra,dec,frame_size, epoch))
-		count++;
-	    }
+              if((*tester)(&newStar,ra,dec,frame_size, epoch, maglim))
+                count++;
+            }
         }
       else
         {
@@ -294,7 +297,7 @@ int posCount(double raMin, double raMax, double decMin, double decMax, testfunc 
                 continue;
               id = newStar.source_id;
 
-              if((*tester)(&newStar,ra,dec,frame_size, epoch))
+              if((*tester)(&newStar,ra,dec,frame_size, epoch, maglim))
 		count++;
 	    }
 
@@ -321,7 +324,7 @@ int posCount(double raMin, double raMax, double decMin, double decMax, testfunc 
                 continue;
               id = newStar.source_id;
 
-              if((*tester)(&newStar,ra,dec,frame_size, epoch))
+              if((*tester)(&newStar,ra,dec,frame_size, epoch, maglim))
 		count++;
 	    }
 	}
@@ -331,11 +334,13 @@ int posCount(double raMin, double raMax, double decMin, double decMax, testfunc 
 
     }
   free(catpath);
+  printf("%d stars found\n", count);
   return count;
 
 }
 // returns list of stars based on ra and dec range
-int posQuery(double raMin, double raMax, double decMin, double decMax, testfunc tester,double ra,double dec, double frame_size, const double *epoch,gaiastar stars[])
+int posQuery(double raMin, double raMax, double decMin, double decMax, testfunc tester,double ra,double dec, double frame_size,
+        const double *epoch, const maglims* maglim, gaiastar stars[])
 {
   int count = 0;
 
@@ -404,7 +409,7 @@ int posQuery(double raMin, double raMax, double decMin, double decMax, testfunc 
                 continue;
               id = newStar.source_id;
 
-              if((*tester)(&newStar,ra,dec,frame_size, epoch))
+              if((*tester)(&newStar,ra,dec,frame_size, epoch, maglim))
 		{
 		stars[count]=newStar;
 		count++;
@@ -434,7 +439,7 @@ int posQuery(double raMin, double raMax, double decMin, double decMax, testfunc 
                 continue;
               id = newStar.source_id;
 
-              if((*tester)(&newStar,ra,dec,frame_size, epoch))
+              if((*tester)(&newStar,ra,dec,frame_size, epoch, maglim))
 		{
 		stars[count]=newStar;
 		count++;
@@ -463,7 +468,7 @@ int posQuery(double raMin, double raMax, double decMin, double decMax, testfunc 
                 continue;
               id = newStar.source_id;
 
-              if((*tester)(&newStar,ra,dec,frame_size, epoch))
+              if((*tester)(&newStar,ra,dec,frame_size, epoch, maglim))
 		{
 		stars[count]=newStar;
 		count++;

--- a/gaialib2/gaia2cat.c
+++ b/gaialib2/gaia2cat.c
@@ -8,7 +8,7 @@
 #include "sllist.h"
 #include "gaia2cat.h"
 #include "gaia2ret.h"
-#include "utils.h"                                                                                                                                                                                                                            
+#include "utils.h"
 
 char catpath_Gaia2[MAX_LINE] = { '\0' };
 char catpath_Gaia2Bin[MAX_LINE] = { '\0' };
@@ -76,7 +76,6 @@ void gaia2_getpath()
         free( line );
         fclose( rc );
     }
-    
     return;
 }
 
@@ -104,7 +103,7 @@ int recursiveSearch(FILE *zFile, int rzIndex1, int rzIndex2, double ra,bool mino
   fseek(zFile,raMiddleIndex,SEEK_SET);
   double raMiddle;
   fread((void*)(&raMiddle),sizeof(double),1,zFile);
-  
+
   if (raMiddle<ra)
     {
       fseek(zFile,raMiddleIndex+STARSIZE,SEEK_SET);
@@ -135,11 +134,10 @@ int recursiveSearch(FILE *zFile, int rzIndex1, int rzIndex2, double ra,bool mino
     }
   else
     return rzIndex1+(middleStar)*STARSIZE;
-  
 }
 
 // Binary Search method for finding star in ra and dec range
-int binarySearch(FILE *zFile, int raZone, double ra, bool minormax)//true for min false for max                                                                                                                                                                                
+int binarySearch(FILE *zFile, int raZone, double ra, bool minormax)//true for min false for max
 {
   fseek(zFile,4*raZone,SEEK_SET);
   int rzIndex2;
@@ -155,7 +153,7 @@ int binarySearch(FILE *zFile, int raZone, double ra, bool minormax)//true for mi
       fread((void*)(&rzIndex1),sizeof(int),1,zFile);
       rzIndex1=rzIndex1*STARSIZE+4*1440;
     }
-  //rzIndex1 is the index for the start of this zone. rzIndex2 is the index for the start of the next zone                                                                                                                                                                      
+  //rzIndex1 is the index for the start of this zone. rzIndex2 is the index for the start of the next zone
   int nStars = (rzIndex2-rzIndex1)/STARSIZE;
 
   int middleStar = nStars/2;
@@ -205,8 +203,7 @@ int posCount(double raMin, double raMax, double decMin, double decMax, testfunc 
 
   bool noRA0 = raMax > raMin;
 
-  //dec zones go from 1 to 900                                                                                                                                                                                                                                                 
-                                                                                                                                                                                                                                                                                
+  //dec zones go from 1 to 900
   double dMinPos = decMin + 90.0;
   double dMaxPos = decMax + 90.0;
   int dMinZone = (int)(dMinPos/0.2)+1;
@@ -216,8 +213,7 @@ int posCount(double raMin, double raMax, double decMin, double decMax, testfunc 
   if (dMaxPos==180.0)
     dMaxZone=900;
 
-  //ra zones go from 0 to 1439                                                                                                                                                                                                                                                 
-                                                                                                                                                                                                                                                                                
+  //ra zones go from 0 to 1439
   int rMinZone = (int)((raMin)/0.25);
   if(raMin == 360.0)
     rMinZone = 1439;
@@ -243,23 +239,20 @@ int posCount(double raMin, double raMax, double decMin, double decMax, testfunc 
 
       if(noRA0)
         {
-          //for the minimum ra:                                                                                                                                                                                                                                                
-                                                                                                                                                                                                                                                                                
+          //for the minimum ra:
           int minIndex = binarySearch(zFile,rMinZone,raMin,true);
 
-          //for the max ra:                                                                                                                                                                                                                                                   
-                                                                                                                                                                                                                                                                                
+          //for the max ra:
           int maxIndex = binarySearch(zFile,rMaxZone,raMax,false);
 
-          // during the initial run for gaia2writebin.c, there was a point where the program failed and stopped. Because of the vast size of the Gaia DR2,                                                                                                                      
-          // I decided not to start the run from scratch, but continued where the initial run left off. However, because of this, there may be a few duplicates                                                                                                                 
-          // of stars within my sortedBin files. Thus, I include a small check here to eliminate such duplicates.                                                                                                                                                               
-          long id = 0; //test for duplicates by comparing adjacent ids.                                                                                                                                                                                                         
+          // during the initial run for gaia2writebin.c, there was a point where the program failed and stopped. Because of the vast size of the Gaia DR2,
+          // I decided not to start the run from scratch, but continued where the initial run left off. However, because of this, there may be a few duplicates
+          // of stars within my sortedBin files. Thus, I include a small check here to eliminate such duplicates.
+          long id = 0; //test for duplicates by comparing adjacent ids.
 
 	  for (int i = minIndex; i < maxIndex; i+=STARSIZE)
             {
-              //read and store each of the stars, checking dec each time. Add the stars to a list                                                                                                                                                                              
-                                                                                                                                                                                                                                                                                
+              //read and store each of the stars, checking dec each time. Add the stars to a list
               fseek(zFile, i+32, SEEK_SET);
               double starDec;
               fread((void*)(&starDec), sizeof(double),1, zFile);
@@ -269,7 +262,7 @@ int posCount(double raMin, double raMax, double decMin, double decMax, testfunc 
               gaiastar newStar;
               fread((void*)(&newStar),sizeof(gaiastar),1,zFile);
 
-              if (newStar.source_id==id) // testing for duplicates                                                                                                                                                                                                              
+              if (newStar.source_id==id) // testing for duplicates
                 continue;
               id = newStar.source_id;
 
@@ -280,15 +273,13 @@ int posCount(double raMin, double raMax, double decMin, double decMax, testfunc 
       else
         {
           long id = 0;
-          //part 1: east                                                                                                                                                                                                                                                       
-                                                                                                                                                                                                                                                                                
+          //part 1: east
           int minIndex = binarySearch(zFile,0,0.0,true);
           int maxIndex = binarySearch(zFile,rMaxZone,raMax,false);
 
           for (int i = minIndex; i < maxIndex; i+=STARSIZE)
             {
-              //read and store each of the stars, checking dec each time. Add the stars to a list                                                                                                                                                                               
-                                                                                                                                                                                                                                                                               
+              //read and store each of the stars, checking dec each time. Add the stars to a list
 
               fseek(zFile, i+32, SEEK_SET);
               double starDec;
@@ -299,7 +290,7 @@ int posCount(double raMin, double raMax, double decMin, double decMax, testfunc 
               gaiastar newStar;
               fread((void*)(&newStar),sizeof(gaiastar),1,zFile);
 
-              if (newStar.source_id==id)// testing for duplicates                                                                                                                                                                                                               
+              if (newStar.source_id==id)// testing for duplicates
                 continue;
               id = newStar.source_id;
 
@@ -309,14 +300,13 @@ int posCount(double raMin, double raMax, double decMin, double decMax, testfunc 
 
 	  id = 0;
 
-	  //part 2: west                                                                                                                                                                                                                                                       
-                                                                                                                                                                                                                                                                                
+	  //part 2: west
 	  minIndex = binarySearch(zFile,rMinZone,raMin,true);
 	  maxIndex = binarySearch(zFile,1439,360.0,false);
 
           for (int i = minIndex; i < maxIndex; i+=STARSIZE)
             {
-              //read and store each of the stars, checking dec each time. Add the stars to a list                                                                                                                                                                               
+              //read and store each of the stars, checking dec each time. Add the stars to a list
 
               fseek(zFile, i+32, SEEK_SET);
               double starDec;
@@ -327,7 +317,7 @@ int posCount(double raMin, double raMax, double decMin, double decMax, testfunc 
               gaiastar newStar;
               fread((void*)(&newStar),sizeof(gaiastar),1,zFile);
 
-              if (newStar.source_id==id)// testing for duplicates                                                                                                                                                                                                               
+              if (newStar.source_id==id)// testing for duplicates
                 continue;
               id = newStar.source_id;
 
@@ -350,8 +340,8 @@ int posQuery(double raMin, double raMax, double decMin, double decMax, testfunc 
   int count = 0;
 
   bool noRA0 = raMax > raMin;
-  
-  //dec zones go from 1 to 900                                                                                                                                                                                                                                                  
+
+  //dec zones go from 1 to 900
   double dMinPos = decMin + 90.0;
   double dMaxPos = decMax + 90.0;
   int dMinZone = (int)(dMinPos/0.2)+1;
@@ -361,7 +351,7 @@ int posQuery(double raMin, double raMax, double decMin, double decMax, testfunc 
   if (dMaxPos==180.0)
     dMaxZone=900;
 
-  //ra zones go from 0 to 1439                                                                                                                                                                                                                                                  
+  //ra zones go from 0 to 1439
   int rMinZone = (int)((raMin)/0.25);
   if(raMin == 360.0)
     rMinZone = 1439;
@@ -387,10 +377,10 @@ int posQuery(double raMin, double raMax, double decMin, double decMax, testfunc 
 
         if(noRA0)
         {
-          //for the minimum ra:                                                                                                                                                                                                                                                 
+          //for the minimum ra:
           int minIndex = binarySearch(zFile,rMinZone,raMin,true);
 
-          //for the max ra:                                                                                                                                                                                                                                                     
+          //for the max ra:
           int maxIndex = binarySearch(zFile,rMaxZone,raMax,false);
 
           // during the initial run for gaia2writebin.c, there was a point where the program failed and stopped. Because of the vast size of the Gaia DR2,
@@ -400,7 +390,7 @@ int posQuery(double raMin, double raMax, double decMin, double decMax, testfunc 
 
            for (int i = minIndex; i < maxIndex; i+=STARSIZE)
             {
-              //read and store each of the stars, checking dec each time. Add the stars to a list                                                                                                                                                                               
+              //read and store each of the stars, checking dec each time. Add the stars to a list
               fseek(zFile, i+32, SEEK_SET);
               double starDec;
               fread((void*)(&starDec), sizeof(double),1, zFile);
@@ -424,14 +414,13 @@ int posQuery(double raMin, double raMax, double decMin, double decMax, testfunc 
          else
         {
 	  long id = 0;
-          //part 1: east                                                                                                                                                                                                                                                        
+          //part 1: east
 	  int minIndex = binarySearch(zFile,0,0.0,true);
           int maxIndex = binarySearch(zFile,rMaxZone,raMax,false);
-	 
+
 	  for (int i = minIndex; i < maxIndex; i+=STARSIZE)
             {
-              //read and store each of the stars, checking dec each time. Add the stars to a list                                                                                                              
-                                                                                                                                                                                                                                                                                
+              //read and store each of the stars, checking dec each time. Add the stars to a list
               fseek(zFile, i+32, SEEK_SET);
               double starDec;
               fread((void*)(&starDec), sizeof(double),1, zFile);
@@ -453,10 +442,10 @@ int posQuery(double raMin, double raMax, double decMin, double decMax, testfunc 
 		}
 
             id = 0;
-          //part 2: west                                                                                                                                                                                                                                                        
+          //part 2: west
 	     minIndex = binarySearch(zFile,rMinZone,raMin,true);
 	     maxIndex = binarySearch(zFile,1439,360.0,false);
-	   
+
 	  for (int i = minIndex; i < maxIndex; i+=STARSIZE)
             {
               //read and store each of the stars, checking dec each time. Add the stars to a list

--- a/gaialib2/gaia2cat.h
+++ b/gaialib2/gaia2cat.h
@@ -11,3 +11,7 @@ typedef bool (*testfunc) (
 int posQuery(double raMin, double raMax, double decMin, double decMax, testfunc tester,double ra,double dec, double frame_size, const double *epoch,gaiastar stars[]);
 
 int posCount(double raMin, double raMax, double decMin, double decMax, testfunc tester,double ra,double dec, double frame_size, const double *epoch);
+
+void gaia2_setpath( const char* path );
+
+void gaia2_getpath();

--- a/gaialib2/gaia2cat.h
+++ b/gaialib2/gaia2cat.h
@@ -1,16 +1,20 @@
 #include <stdbool.h>
+#include "gaia2ret.h"
 
 typedef bool (*testfunc) (
     gaiastar*          star,
     double             centRA,
     double             centDec,
     double             half_size,
-    const double*       epoch
+    const double*      epoch,
+    const maglims*     maglim
 );
 
-int posQuery(double raMin, double raMax, double decMin, double decMax, testfunc tester,double ra,double dec, double frame_size, const double *epoch,gaiastar stars[]);
+int posQuery(double raMin, double raMax, double decMin, double decMax, testfunc tester,double ra,double dec, double frame_size,
+        const double *epoch, const maglims* maglim, gaiastar stars[]);
 
-int posCount(double raMin, double raMax, double decMin, double decMax, testfunc tester,double ra,double dec, double frame_size, const double *epoch);
+int posCount(double raMin, double raMax, double decMin, double decMax, testfunc tester,double ra,double dec, double frame_size,
+        const double *epoch, const maglims* maglim);
 
 void gaia2_setpath( const char* path );
 

--- a/gaialib2/gaia2idsort.h
+++ b/gaialib2/gaia2idsort.h
@@ -1,0 +1,7 @@
+typedef struct
+{
+  long sourceID;
+  long position;
+  int zone;
+
+}IDElement;

--- a/gaialib2/gaia2read.c
+++ b/gaialib2/gaia2read.c
@@ -238,6 +238,7 @@ int main(int argc, char** argv)
                     if ( !myoptarg && cent_ra_set && cent_dec_set ) {
                         // Use search center for xi-eta coordinates
                         xieta_center = &center;
+                        print_xieta = true;
                     }
                     else if ( myoptarg ) {
                         char* myoptargcopy = strdup(myoptarg);
@@ -745,6 +746,11 @@ void help()
 " --idfile <path>       : read IDs (see option -g) from file",
 " --precess <equinox>   : apply correction for precession for a given equinox",
 " --pm <epoch>          : apply correction for proper motions. Epoch is in years",
+" --xieta-coords <ra>,<dec> : output xi/eta coordinates centered at given sky position, defaulting to search center",
+" --mG|-m <G_min>       : bright G magnitude cutoff",
+" --MG|-M <G_max>       : faint G magnitude cutoff",
+" --mf <f_min>          : minimum magnitude in band f, where f is 'G', 'R', or 'B'",
+" --Mf <f_max>          : maximum magnitude in band f, where f is 'G', 'R', or 'B'",
 " --out|-o <file>       : output file",
 " --cmdline             : prints command line first",
 " --version|-v          : prints out version",

--- a/gaialib2/gaia2read.c
+++ b/gaialib2/gaia2read.c
@@ -29,7 +29,7 @@
 //includes option flag to request based on input of gaia id, hat id, or 2 mass id
 
 enum {
-    //arg_catpath,
+    arg_catpath,
     arg_header,
     //arg_outphot,
     //arg_estphot,
@@ -52,8 +52,8 @@ myoptlong longoptions[] =
     { "circ",           no_argument,        'c'         },
     { "id",             required_argument,  'g'         },
     { "idtype",         required_argument,   arg_idtype },
-    //{ "cat",            required_argument,  arg_catpath },
-    //{ "catalog",        required_argument,  arg_catpath },//
+    { "cat",            required_argument,  arg_catpath },
+    { "catalog",        required_argument,  arg_catpath },
     { "header",         no_argument,        arg_header  },
     { "extra",          no_argument,        arg_extra   },
     { "idrequest",     required_argument,  arg_idrequest  },
@@ -97,6 +97,11 @@ int main(int argc, char** argv)
     const char* idFile            = NULL;
     int idcount = 0;//number of id stars added to list
     int opt;
+
+    if(argc == 1) {
+      usage();
+      exit(0);
+    }
 
     while ((opt = mygetopt(argc, argv, "r:d:p:s:cg:o:vh", longoptions)) != NO_MORE_OPTIONS)
     {
@@ -156,6 +161,10 @@ int main(int argc, char** argv)
 	        case 'g':           // --id
                 gID = myoptarg;
 	            break;
+
+                case arg_catpath:   // --cat, --catalog
+            		gaia2_setpath( myoptarg );
+            		break;
 
 	        case arg_idtype:    // --what type of ids are the input
                 if ( !astrio_parseID(myoptarg, &inputIDType, NULL))
@@ -219,6 +228,9 @@ int main(int argc, char** argv)
 	            usage();
         }
     }
+
+    /* Make sure the catalog path is set */
+    gaia2_getpath( );
 
     // collect ID information from arguments 'g' and arg_idfile
     if (gID != NULL)
@@ -343,6 +355,7 @@ int main(int argc, char** argv)
 	  sllist* altIDs = starListToIDs(stars,specify_idOut,count);
             gaiastar_printlist_alternateID(os, stars, print_extra, altIDs, specify_idOut,count);
         }
+
     }
     else {
         const double* pJD = epoch ? &JD : NULL;
@@ -402,16 +415,23 @@ local int toLongID(const char* id,IDType inputIDType,char* longID)
 {
   if(inputIDType==HAT)
     {
-      longID[strlen(id)-4]=id[0];
-      longID[strlen(id)-3]=id[1];
-      longID[strlen(id)-2]=id[2];
+      unsigned int i1;
+      unsigned int i2;
       unsigned int i;
-      for(i = 4; i < strlen(id);i++)
-	{
-	  longID[i-4]=id[i];
-	}
-      longID[i-1]='\0';
-      printf("%s %s\n",id,longID);
+      i = 0;
+      while(!(id[i] >= '0' && id[i] <= '9')) i++;
+      sscanf(&(id[i]),"%u-%u",&i1,&i2);
+      sprintf(longID,"%u%u",i2,i1);
+      //longID[strlen(id)-4]=id[0];
+      //longID[strlen(id)-3]=id[1];
+      //longID[strlen(id)-2]=id[2];
+      //unsigned int i;
+      //for(i = 4; i < strlen(id);i++)
+      //{
+      //  longID[i-4]=id[i];
+      //}
+      //longID[i-1]='\0';
+      //printf("%s %s\n",id,longID);
       return 0;
 
     }

--- a/gaialib2/gaia2ret.c
+++ b/gaialib2/gaia2ret.c
@@ -18,6 +18,9 @@
 IDElement recurseID(long start, long end, long gaiaID, FILE *idFile);
 gaiastar getStarfromID(long gaiaID, const double *epoch);
 
+extern char catpath_Gaia2Bin[MAX_LINE];
+extern char catpath_Gaia2Mass[MAX_LINE];
+
 int starPosCount(double ra, double dec, bool circle, double frame_size,const double *epoch)
 {
   if (!circle)
@@ -206,18 +209,25 @@ long recurseNewID(long start, long end, long ID, FILE *idFile, IDType intype, ID
 sllist* starListToIDs(gaiastar stars[], IDType outID, int count)
 {
   sllist *idList = NULL;
+  if(count <= 0) return idList;
+  char *gaiaFileName = concat(catpath_Gaia2Mass,"IDgaiaSort");
+  //FILE* gaiaFile = fopen("/home/jkim/work/Gaia2Mass/IDgaiaSort","rb");
+  FILE* gaiaFile = fopen(gaiaFileName,"rb");
+  if (gaiaFile==NULL) {
+    printf("ERROR: could not open file %s\n", gaiaFileName);
+    exit(EXIT_FAILURE);
+  }
   for (int i = 0; i < count; i++) {
     const gaiastar* star = &stars[i];
     long gaiaID = star->source_id;
          
-    FILE* gaiaFile = fopen("/home/jkim/work/Gaia2Mass/IDgaiaSort","rb");
-    if (gaiaFile==NULL)
-      printf("ERROR: file could not open");
     long other = recurseNewID(0,450646602,gaiaID,gaiaFile,GAIA,outID);
 
     slappend(&idList,&other,sizeof(long));
     
-    }
+  }
+  free(gaiaFileName);
+  fclose(gaiaFile);
   return idList;
 
 }
@@ -228,15 +238,23 @@ char* toGaiaID(const char* otherID, IDType inID, char* buffer)
   if (inID==GAIA)
     return (char*)otherID;
   FILE *sortedFile;
+  char *sortedFileName = NULL;
   if (inID==TMASS)
-    sortedFile = fopen("/home/jkim/work/Gaia2Mass/IDtmassSort","rb");
+    sortedFileName = concat(catpath_Gaia2Mass,"IDtmassSort");
   else
-    sortedFile = fopen("/home/jkim/work/Gaia2Mass/IDhatSort","rb");
-  if(sortedFile==NULL)
-    printf("ERROR: could not open file");
+    sortedFileName = concat(catpath_Gaia2Mass,"IDhatSort");
+  //sortedFile = fopen("/home/jkim/work/Gaia2Mass/IDtmassSort","rb");
+  //sortedFile = fopen("/home/jkim/work/Gaia2Mass/IDhatSort","rb");
+  sortedFile = fopen(sortedFileName,"rb");
+  if(sortedFile==NULL) {
+    printf("ERROR: could not open file %s\n",sortedFileName);
+    exit(EXIT_FAILURE);
+  }
   long other = strtol(otherID,NULL,10);
   long gaiaID = recurseNewID(0,450646602,other,sortedFile,inID,GAIA);
   fclose(sortedFile);
+  if(sortedFileName != NULL)
+    free(sortedFileName);
   sprintf(buffer,"%ld",gaiaID);
   return buffer;
 }
@@ -337,54 +355,64 @@ gaiastar getStarfromID(long gaiaID, const double *epoch)
 	int numStars;
 	if (stringID[0]=='1')
 	{
-		fileName = "/home/jkim/work/Gaia2Bin/IDSTSort/id1";
-		numStars = 116724371;
+	  fileName = concat(catpath_Gaia2Bin,"IDSTSort/id1");
+	  //fileName = "/home/jkim/work/Gaia2Bin/IDSTSort/id1";
+	  numStars = 116724371;
 	}
 	else if (stringID[0]=='2')
 	{
-		fileName = "/home/jkim/work/Gaia2Bin/IDSTSort/id2";
-		numStars = 163285128;
+	  fileName = concat(catpath_Gaia2Bin,"IDSTSort/id2");
+	  //fileName = "/home/jkim/work/Gaia2Bin/IDSTSort/id2";
+	  numStars = 163285128;
 	}
 	else if (stringID[0]=='3')
 	{
-		fileName = "/home/jkim/work/Gaia2Bin/IDSTSort/id3";
-		numStars = 87098579;
+	  fileName = concat(catpath_Gaia2Bin,"IDSTSort/id3");
+	  //fileName = "/home/jkim/work/Gaia2Bin/IDSTSort/id3";
+	  numStars = 87098579;
 	}
 	else if (stringID[0]=='4')
 	{
-		fileName = "/home/jkim/work/Gaia2Bin/IDSTSort/id4";
-		numStars = 585793870;
+	  fileName = concat(catpath_Gaia2Bin,"IDSTSort/id4");
+	  //fileName = "/home/jkim/work/Gaia2Bin/IDSTSort/id4";
+	  numStars = 585793870;
 	}
 	else if (stringID[0]=='5')
 	{
-		fileName = "/home/jkim/work/Gaia2Bin/IDSTSort/id5";
-		numStars = 531853513;
+	  fileName = concat(catpath_Gaia2Bin,"IDSTSort/id5");
+	  //fileName = "/home/jkim/work/Gaia2Bin/IDSTSort/id5";
+	  numStars = 531853513;
 	}
 	else if (stringID[0]=='6')
 	{
-		fileName = "/home/jkim/work/Gaia2Bin/IDSTSort/id6";
-		numStars = 203648450;
+	  fileName = concat(catpath_Gaia2Bin,"IDSTSort/id6");
+	  //fileName = "/home/jkim/work/Gaia2Bin/IDSTSort/id6";
+	  numStars = 203648450;
 	}
 	else if (stringID[0]=='7')
 	{
-		fileName = "/home/jkim/work/Gaia2Bin/IDSTSort/id7";
-		numStars = 1990817;
+	  fileName = concat(catpath_Gaia2Bin,"IDSTSort/id7");
+	  //fileName = "/home/jkim/work/Gaia2Bin/IDSTSort/id7";
+	  numStars = 1990817;
 	}
 	else if (stringID[0]=='8')
 	{
-		fileName = "/home/jkim/work/Gaia2Bin/IDSTSort/id8";
-		numStars = 3698075;
+	  fileName = concat(catpath_Gaia2Bin,"IDSTSort/id8");
+	  //fileName = "/home/jkim/work/Gaia2Bin/IDSTSort/id8";
+	  numStars = 3698075;
 	}
 	else
 	{
-		fileName = "/home/jkim/work/Gaia2Bin/IDSTSort/id9";
-		numStars = 6507262;
+	  fileName = concat(catpath_Gaia2Bin,"IDSTSort/id9");
+	  //fileName = "/home/jkim/work/Gaia2Bin/IDSTSort/id9";
+	  numStars = 6507262;
 	}
 
 	FILE *idFile = fopen(fileName,"rb");
     // use binary search to find the id within the file
 	IDElement targetID = recurseID(0, numStars, gaiaID, idFile);
 	fclose(idFile);
+	free(fileName);
 	if (targetID.sourceID==0)
 	{
 		printf("ERROR: Gaia ID Query does not exist");
@@ -392,7 +420,7 @@ gaiastar getStarfromID(long gaiaID, const double *epoch)
 	}
 	char zone[4];
 	sprintf(zone,"%d",targetID.zone);
-	char * catpath = "/home/jkim/work/Gaia2Bin/sortedBin/z";
+	char * catpath = concat(catpath_Gaia2Bin,"sortedBin/z");
 	char *zoneFileName = concat(catpath,zone);
 
 	FILE *zoneFile = fopen(zoneFileName,"rb");
@@ -400,6 +428,8 @@ gaiastar getStarfromID(long gaiaID, const double *epoch)
 	gaiastar targetStar;
 	fread((void*)&targetStar,sizeof(gaiastar),1,zoneFile);
 	fclose(zoneFile);
+	free(zoneFileName);
+	free(catpath);
 
     // apply proper motion if necessary
     if ( epoch ) {

--- a/gaialib2/gaia2ret.c
+++ b/gaialib2/gaia2ret.c
@@ -513,17 +513,17 @@ bool test_star(gaiastar* star, double centRA, double centDec, double half_size, 
         return false;
     // Not all Gaia stars have RP and BP magnitudes in GaiaDR2, so check for this
     // n/a values were stored as 3.55: see DataPreparation/gaia2writebin.c
-    if (maglim -> minBpmag && fabs(3.55 - star->phot_bp_mean_mag)<1e-7
-            && star->phot_bp_mean_mag < *maglim->minBpmag)
+    if (maglim -> minBpmag && (fabs(3.55 - star->phot_bp_mean_mag)<1e-7
+            || star->phot_bp_mean_mag < *maglim->minBpmag))
         return false;
-    if (maglim -> maxBpmag && fabs(3.55 - star->phot_bp_mean_mag)<1e-7
-            && star->phot_bp_mean_mag > *maglim->maxBpmag)
+    if (maglim -> maxBpmag && (fabs(3.55 - star->phot_bp_mean_mag)<1e-7
+            || star->phot_bp_mean_mag > *maglim->maxBpmag))
         return false;
-    if (maglim -> minRpmag && fabs(3.55 - star->phot_rp_mean_mag)<1e-7
-            && star->phot_rp_mean_mag < *maglim->minRpmag)
+    if (maglim -> minRpmag && (fabs(3.55 - star->phot_rp_mean_mag)<1e-7
+            || star->phot_rp_mean_mag < *maglim->minRpmag))
         return false;
-    if (maglim -> maxRpmag && fabs(3.55 - star->phot_rp_mean_mag)<1e-7
-            && star->phot_rp_mean_mag > *maglim->maxRpmag)
+    if (maglim -> maxRpmag && (fabs(3.55 - star->phot_rp_mean_mag)<1e-7
+            || star->phot_rp_mean_mag > *maglim->maxRpmag))
         return false;
   }
 
@@ -562,6 +562,20 @@ bool test_starcirc(gaiastar* star,double centRA,double centDec,double radius, co
     if ( maglim->minGmag && star->phot_g_mean_mag < *maglim->minGmag)
         return false;
     if ( maglim->maxGmag && star->phot_g_mean_mag > *maglim->maxGmag)
+        return false;
+    // Not all Gaia stars have RP and BP magnitudes in GaiaDR2, so check for this
+    // n/a values were stored as 3.55: see DataPreparation/gaia2writebin.c
+    if (maglim -> minBpmag && (fabs(3.55 - star->phot_bp_mean_mag)<1e-7
+            || star->phot_bp_mean_mag < *maglim->minBpmag))
+        return false;
+    if (maglim -> maxBpmag && (fabs(3.55 - star->phot_bp_mean_mag)<1e-7
+            || star->phot_bp_mean_mag > *maglim->maxBpmag))
+        return false;
+    if (maglim -> minRpmag && (fabs(3.55 - star->phot_rp_mean_mag)<1e-7
+            || star->phot_rp_mean_mag < *maglim->minRpmag))
+        return false;
+    if (maglim -> maxRpmag && (fabs(3.55 - star->phot_rp_mean_mag)<1e-7
+            || star->phot_rp_mean_mag > *maglim->maxRpmag))
         return false;
   }
   // apply pm

--- a/gaialib2/gaia2ret.h
+++ b/gaialib2/gaia2ret.h
@@ -9,11 +9,22 @@ typedef enum
 	GAIA,HAT,TMASS
 } IDType;
 
+typedef struct {
+    const double* minGmag;
+    const double* maxGmag;
+    const double* minRpmag;
+    const double* maxRpmag;
+    const double* minBpmag;
+    const double* maxBpmag;
+} maglims;
+
 // returns count of stars in for the size of an array
-int starPosCount(double ra, double dec, bool circle, double frame_size,const double *epoch);
+int starPosCount(double ra, double dec, bool circle, double frame_size, const double *epoch,
+        const maglims* maglim);
 
 // returns list of stars given size, circle or rectangular, and center ra and dec
-int starPosSearch(double ra, double dec, bool circle, double frame_size, const double *epoch,gaiastar* stars);
+int starPosSearch(double ra, double dec, bool circle, double frame_size, const double *epoch,
+        const maglims* maglim, gaiastar* stars);
 
 // get list of stars from a list of Gaia IDs
 int starsfromID(sllist* longIDs, const double *epoch,gaiastar* stars);
@@ -25,10 +36,12 @@ sllist* starListToIDs(gaiastar* stars, IDType outID,int count);
 char* toGaiaID(const char* otherID, IDType inID, char* buffer);
 
 // checks to make sure star is within box and applies proper motion
-bool test_star(gaiastar* star, double centRA, double centDec, double half_size, const double *epoch);
+bool test_star(gaiastar* star, double centRA, double centDec, double half_size, const double *epoch,
+        const maglims* maglim);
 
 // tests star to make sure it is within the circle and then applies proper motion
-bool test_starcirc(gaiastar* star,double centRA,double centDec,double radius, const double *epoch);
+bool test_starcirc(gaiastar* star,double centRA,double centDec,double radius, const double *epoch,
+        const maglims* maglim);
 
 #endif
 

--- a/gaialib2/gaiaPrint.c
+++ b/gaialib2/gaiaPrint.c
@@ -1,271 +1,267 @@
 #include <stdbool.h>
 #include <string.h>
 #include <math.h>
+#include "gaiaPrint.h"
 #include "gaiastar.h"
-#include "gaia2ret.h"
-#include "sllist.h"
 
 // format for printing float
 local void printFloat(FILE* out, float val, char* format){//format should have a space in front of it
-  if (fabs(3.55-val)<1e-7)
-    {
-      char *naFormat;
-      if(strcmp(format," %14.10f")==0)
-	naFormat = " %14s";
-      else
-	naFormat = " %9s";
-      char *na = "n/a";
-      fprintf(out,naFormat,na);
+    if (fabs(3.55-val)<1e-7) {
+        char *naFormat;
+        if ( strcmp(format," %14.10f")==0 )
+            naFormat = " %14s";
+        else
+            naFormat = " %9s";
+        char *na = "n/a";
+        fprintf(out,naFormat,na);
     }
-  else
-    fprintf(out,format,val);
+    else
+        fprintf(out,format,val);
 }
 
 // format for printing double
 local void printDouble(FILE* out, double val, char* format){//format should have a space in front of it
-  if (fabs(3.55-val)<1e-7){
-    char *naFormat;
-    if(strcmp(format," %14.10f")==0)
-      naFormat = " %14s";
-    else
-      naFormat = " %9s";
-    char *na = "n/a";
-    fprintf(out,naFormat,na);
+  if (fabs(3.55-val)<1e-7) {
+      char *naFormat;
+      if(strcmp(format," %14.10f")==0)
+          naFormat = " %14s";
+      else
+          naFormat = " %9s";
+      char *na = "n/a";
+      fprintf(out,naFormat,na);
   }
   else
-    fprintf(out,format,val);
+      fprintf(out,format,val);
 }
 
 // default print options
 local void print_common(FILE* out, const gaiastar* star, long id,IDType type){
-  if(type==GAIA) {
-    if(id==0)
-      id = star->source_id;
-    fprintf(out, "%ld",id);
-  }
-  else if(type==TMASS)
-    {
-      if(id == 0) {
-	id = star->source_id;
-	fprintf(out, "%ld",id);
-      }
-      else {
-	char tmassID[16];
-	char str[16];
-	sprintf(str,"%ld",id);
-	if(str[0]=='1')
-	  {
-	    tmassID[0]=str[1];
-	    tmassID[1]=str[2];
-	    tmassID[2]=str[3];
-	    tmassID[3]=str[4];
-	    tmassID[4]=str[5];
-	    tmassID[5]=str[6];
-	    tmassID[6]=str[7];
-	    tmassID[7]=str[8];
-	    tmassID[8]='+';
-	    tmassID[9]=str[9];
-	    tmassID[10]=str[10];
-	    tmassID[11]=str[11];
-	    tmassID[12]=str[12];
-	    tmassID[13]=str[13];
-	    tmassID[14]=str[14];
-	    tmassID[15]=str[15];
-	  }
-	else
-	  {
-	    tmassID[0]=str[1];
-	    tmassID[1]=str[2];
-	    tmassID[2]=str[3];
-	    tmassID[3]=str[4];
-	    tmassID[4]=str[5];
-	    tmassID[5]=str[6];
-	    tmassID[6]=str[7];
-	    tmassID[7]=str[8];
-	    tmassID[8]='-';
-	    tmassID[9]=str[9];
-	    tmassID[10]=str[10];
-	    tmassID[11]=str[11];
-	    tmassID[12]=str[12];
-	    tmassID[13]=str[13];
-	    tmassID[14]=str[14];
-	    tmassID[15]=str[15];
-	    
-	  }
-	fprintf(out,"%s",tmassID);
-      }
-
+    if(type==GAIA) {
+        if(id==0)
+            id = star->source_id;
+        fprintf(out, "%ld",id);
     }
-  else if(type==HAT)
-    {
-      if(id == 0) {
-	id = star->source_id;
-	fprintf(out, "%ld",id);
-      }
-      else {
-	char hatID[20];
-	sprintf(hatID,"%03d-%07d",((int) (id % 1000)),((int) (id / 1000)));
-	fprintf(out,"%s",hatID);
-      }
+    else if(type==TMASS) {
+        if(id == 0) {
+            id = star->source_id;
+            fprintf(out, "%ld",id);
+        }
+        else {
+            char tmassID[16];
+            char str[16];
+            sprintf(str,"%ld",id);
+            if (str[0]=='1') {
+                tmassID[0]=str[1];
+                tmassID[1]=str[2];
+                tmassID[2]=str[3];
+                tmassID[3]=str[4];
+                tmassID[4]=str[5];
+                tmassID[5]=str[6];
+                tmassID[6]=str[7];
+                tmassID[7]=str[8];
+                tmassID[8]='+';
+                tmassID[9]=str[9];
+                tmassID[10]=str[10];
+                tmassID[11]=str[11];
+                tmassID[12]=str[12];
+                tmassID[13]=str[13];
+                tmassID[14]=str[14];
+                tmassID[15]=str[15];
+            }
+            else {
+                tmassID[0]=str[1];
+                tmassID[1]=str[2];
+                tmassID[2]=str[3];
+                tmassID[3]=str[4];
+                tmassID[4]=str[5];
+                tmassID[5]=str[6];
+                tmassID[6]=str[7];
+                tmassID[7]=str[8];
+                tmassID[8]='-';
+                tmassID[9]=str[9];
+                tmassID[10]=str[10];
+                tmassID[11]=str[11];
+                tmassID[12]=str[12];
+                tmassID[13]=str[13];
+                tmassID[14]=str[14];
+                tmassID[15]=str[15];
+            }
+            fprintf(out,"%s",tmassID);
+        }
     }
-  printDouble(out,star->ra," %14.10f");
-  printDouble(out,star->dec," %14.10f");
-  printDouble(out,star->ra_error," %14.10f");
-  printDouble(out,star->dec_error," %14.10f");
-  printDouble(out,star->parallax," %9.4f");
-  printDouble(out,star->parallax_error," %9.4f");
-  printDouble(out,star->pmra," %14.10f");
-  printDouble(out,star->pmdec," %14.10f");
-  printDouble(out,star->pmra_error," %14.10f");
-  printDouble(out,star->pmdec_error," %14.10f");
-  printDouble(out,star->ref_epoch," %5.1f");
-  printDouble(out,star->astrometric_excess_noise," %14.10f");
-  printDouble(out,star->astrometric_excess_noise_sig," %14.10f");
-  if(star->astrometric_primary_flag)
-    fprintf(out," true");
-  else
-    fprintf(out," false");
+    else if(type==HAT) {
+        if(id == 0) {
+            id = star->source_id;
+            fprintf(out, "%ld",id);
+        }
+        else {
+            char hatID[20];
+            sprintf(hatID,"%03d-%07d",((int) (id % 1000)),((int) (id / 1000)));
+            fprintf(out,"%s",hatID);
+        }
+    }
+    printDouble(out,star->ra," %14.10f");
+    printDouble(out,star->dec," %14.10f");
+    printDouble(out,star->ra_error," %14.10f");
+    printDouble(out,star->dec_error," %14.10f");
+    printDouble(out,star->parallax," %9.4f");
+    printDouble(out,star->parallax_error," %9.4f");
+    printDouble(out,star->pmra," %14.10f");
+    printDouble(out,star->pmdec," %14.10f");
+    printDouble(out,star->pmra_error," %14.10f");
+    printDouble(out,star->pmdec_error," %14.10f");
+    printDouble(out,star->ref_epoch," %5.1f");
+    printDouble(out,star->astrometric_excess_noise," %14.10f");
+    printDouble(out,star->astrometric_excess_noise_sig," %14.10f");
+    if(star->astrometric_primary_flag)
+        fprintf(out," true");
+    else
+        fprintf(out," false");
 }
 
 // calls default print options
-void gaiastar_print(FILE* out, const gaiastar* star, long id,IDType type)
+void gaiastar_print(FILE* out, const gaiastar* star, long id, IDType type,
+        skypos* xieta_center)
 {
-  print_common( out, star, id,type);
-  fendl( out );
+    print_common( out, star, id,type);
+    // Calculate xi/eta coordinates
+    if ( xieta_center ) {
+        double xi;
+        double eta;
+        astr_rgnomonic(star->ra, star->dec,
+                xieta_center->RA, xieta_center->Dec, &xi, &eta);
+        fprintf(out, " %14.10f %14.10f", xi, eta);
+    }
+    fendl( out );
 }
 
 // default print options + additional info
-void gaiastar_printextra(FILE* out, const gaiastar* star, long id,IDType type)
+void gaiastar_printextra(FILE* out, const gaiastar* star, long id, IDType type,
+        skypos* xieta_center)
 {
-  print_common( out, star, id,type);
+    print_common( out, star, id,type);
 
-  fprintf(out," %d", star->phot_g_n_obs);
-  printDouble(out,star->phot_g_mean_flux," %14.10f");
-  printDouble(out,star->phot_g_mean_flux_error," %14.10f");
-  printFloat(out,star->phot_g_mean_flux_over_error," %14.10f");
-  printFloat(out,star->phot_g_mean_mag," %14.10f");
+    fprintf(out," %d", star->phot_g_n_obs);
+    printDouble(out,star->phot_g_mean_flux," %14.10f");
+    printDouble(out,star->phot_g_mean_flux_error," %14.10f");
+    printFloat(out,star->phot_g_mean_flux_over_error," %14.10f");
+    printFloat(out,star->phot_g_mean_mag," %14.10f");
 
-  fprintf(out," %d", star->phot_bp_n_obs);
-  printDouble(out,star->phot_bp_mean_flux," %14.10f");
-  printDouble(out,star->phot_bp_mean_flux_error," %14.10f");
-  printFloat(out,star->phot_bp_mean_flux_over_error," %14.10f");
-  printFloat(out,star->phot_bp_mean_mag," %14.10f");
+    fprintf(out," %d", star->phot_bp_n_obs);
+    printDouble(out,star->phot_bp_mean_flux," %14.10f");
+    printDouble(out,star->phot_bp_mean_flux_error," %14.10f");
+    printFloat(out,star->phot_bp_mean_flux_over_error," %14.10f");
+    printFloat(out,star->phot_bp_mean_mag," %14.10f");
 
-  fprintf(out," %d", star->phot_rp_n_obs);
-  printDouble(out,star->phot_rp_mean_flux," %14.10f");
-  printDouble(out,star->phot_rp_mean_flux_error," %14.10f");
-  printFloat(out,star->phot_rp_mean_flux_over_error," %14.10f");
-  printFloat(out,star->phot_rp_mean_mag," %14.10f");
+    fprintf(out," %d", star->phot_rp_n_obs);
+    printDouble(out,star->phot_rp_mean_flux," %14.10f");
+    printDouble(out,star->phot_rp_mean_flux_error," %14.10f");
+    printFloat(out,star->phot_rp_mean_flux_over_error," %14.10f");
+    printFloat(out,star->phot_rp_mean_mag," %14.10f");
 
-  printFloat(out,star->phot_bp_rp_excess_factor," %14.10f");
-  printDouble(out,star->radial_velocity," %14.10f");
-  printDouble(out,star->radial_velocity_error," %14.10f");
-  if(star->phot_variable_flag)
-    fprintf(out," VARIABLE");
-  else
-    fprintf(out," NOT_AVAILABLE");
+    printFloat(out,star->phot_bp_rp_excess_factor," %14.10f");
+    printDouble(out,star->radial_velocity," %14.10f");
+    printDouble(out,star->radial_velocity_error," %14.10f");
+    if(star->phot_variable_flag)
+      fprintf(out," VARIABLE");
+    else
+      fprintf(out," NOT_AVAILABLE");
 
-  printFloat(out,star->teff_val," %14.10f");
-  printFloat(out,star->teff_percentile_lower," %14.10f");
-  printFloat(out,star->teff_percentile_upper," %14.10f");
-  printFloat(out,star->a_g_val," %14.10f");
-  printFloat(out,star->a_g_percentile_lower," %14.10f");
-  printFloat(out,star->a_g_percentile_upper," %14.10f");
-  printFloat(out,star->e_bp_min_rp_val," %14.10f");
-  printFloat(out,star->e_bp_min_rp_percentile_lower," %14.10f");
-  printFloat(out,star->e_bp_min_rp_percentile_upper," %14.10f");
-  printFloat(out,star->radius_val," %14.10f");
-  printFloat(out,star->radius_percentile_lower," %14.10f");
-  printFloat(out,star->radius_percentile_upper," %14.10f");
-  printFloat(out,star->lum_val," %14.10f");
-  printFloat(out,star->lum_percentile_lower," %14.10f");
-  printFloat(out,star->lum_percentile_upper," %14.10f");
-  fprintf(out,"\n");
+    printFloat(out,star->teff_val," %14.10f");
+    printFloat(out,star->teff_percentile_lower," %14.10f");
+    printFloat(out,star->teff_percentile_upper," %14.10f");
+    printFloat(out,star->a_g_val," %14.10f");
+    printFloat(out,star->a_g_percentile_lower," %14.10f");
+    printFloat(out,star->a_g_percentile_upper," %14.10f");
+    printFloat(out,star->e_bp_min_rp_val," %14.10f");
+    printFloat(out,star->e_bp_min_rp_percentile_lower," %14.10f");
+    printFloat(out,star->e_bp_min_rp_percentile_upper," %14.10f");
+    printFloat(out,star->radius_val," %14.10f");
+    printFloat(out,star->radius_percentile_lower," %14.10f");
+    printFloat(out,star->radius_percentile_upper," %14.10f");
+    printFloat(out,star->lum_val," %14.10f");
+    printFloat(out,star->lum_percentile_lower," %14.10f");
+    printFloat(out,star->lum_percentile_upper," %14.10f");
+
+    if ( xieta_center ) {
+        double xi;
+        double eta;
+        astr_rgnomonic(star->ra, star->dec,
+                xieta_center->RA, xieta_center->Dec, &xi, &eta);
+        printDouble(out, xi, " %14.10f");
+        printDouble(out, eta, " %14.10f");
+    }
+
+    fprintf(out,"\n");
 }
 
 // print list of stars with Gaia IDs
-void gaiastar_printlist(FILE* out, const gaiastar stars[], bool extra,int count)
+void gaiastar_printlist(FILE* out, const gaiastar stars[], int count, bool extra, skypos* xieta_center)
 {
-  if ( extra ) {
     for (int i = 0; i < count; i++) {
-      //fprintf(out,"GAIA ");
-      const gaiastar* star = &stars[i];
-      gaiastar_printextra(out, star, 0,GAIA);
+        //fprintf(out,"GAIA ");
+        const gaiastar* star = &stars[i];
+        if ( extra )
+            gaiastar_printextra(out, star, 0, GAIA, xieta_center);
+        else
+            gaiastar_print(out, star, 0, GAIA, xieta_center);
     }
-  }
-  else {
-    for (int i = 0; i < count; i++) {
-      //fprintf(out,"GAIA ");
-      const gaiastar* star = &stars[i];
-      gaiastar_print(out, star, 0,GAIA);
-    }
-  }
 }
 
-// -------------------------------------------------------------------------- +                                                                                                                                                                                                 
+// --------------------------------------------------------------------------
 // print list of stars with specified IDs
-void gaiastar_printlist_alternateID(FILE* out, const gaiastar stars[], bool extra, const sllist* alternateIDs, IDType type,int count)
+void gaiastar_printlist_alternateID(FILE* out, const gaiastar stars[], int count, bool extra,
+        const sllist* alternateIDs, IDType type, skypos* xieta_center)
 {
-  if ( extra ) {
     const sllist* ids = alternateIDs;
     for (int i = 0; i < count; i++ ) {
-      const gaiastar* star = &stars[i];
-      const long* id = (const long*)ids->data;
-      if (type==TMASS && *id!=0)
-	fprintf(out,"2MASS-");
-      else if(type==HAT && *id!=0)
-	fprintf(out,"HAT-");
-      else
-	fprintf(out,"GAIA-");
-
-      gaiastar_printextra(out, star, *id,type);
-      ids = ids->next;
+        const gaiastar* star = &stars[i];
+        const long* id = (const long*)ids->data;
+        if (type==TMASS && *id!=0)
+            fprintf(out,"2MASS-");
+        else if(type==HAT && *id!=0)
+            fprintf(out,"HAT-");
+        else
+            fprintf(out,"GAIA-");
+        if ( extra )
+            gaiastar_printextra(out, star, *id, type, xieta_center);
+        else
+            gaiastar_print(out, star, *id, type, xieta_center);
+        ids = ids->next;
     }
-  }
-  else {
-    const sllist* ids = alternateIDs;
-    for (int i = 0; i<count; i++) {
-      const gaiastar* star = &stars[i];
-      const long* id = (const long*)ids->data;
-      if (type==TMASS && *id!=0)
-        fprintf(out,"2MASS-");
-      else if(type==HAT && *id!=0)
-	fprintf(out,"HAT-");
-      else
-	fprintf(out,"GAIA-");
-
-      gaiastar_print(out, star, *id,type);
-      ids = ids->next;
-    }
-  }
 }
 
 // print header
-void gaiastar_printheader(FILE* out, bool extra, IDType outType)
+void gaiastar_printheader(FILE* out, bool extra, IDType outType, bool print_xieta)
 {
-  char *idString;
-  if (outType == GAIA)
-    idString = "Gaia-";
-  else if (outType == HAT)
-    idString = "HAT-";
-  else
-    idString = "2MASS-";
+    char *idString;
+    if (outType == GAIA)
+        idString = "Gaia-";
+    else if (outType == HAT)
+        idString = "HAT-";
+    else
+        idString = "2MASS-";
 
-  // ID and position                                                                                                                                                                                                                                                            
-  fprintf(out, "#%sID[1] RA[deg][2] Dec[deg][3] RAError[mas][4] DecError[mas][5] Parallax[mas][6] Parallax_error[mas][7] PM_RA[mas/yr][8] PM_Dec[mas/year][9] PMRA_error[mas/yr][10] PMDec_error[mas/yr][11] Ref_Epoch[yr][12]",idString);
-  fprintf(out, " AstExcNoise[mas][13] AstExcNoiseSig[14] AstPriFlag[15] ");
+    // ID and position
+    fprintf(out, "#%sID[1] RA[deg][2] Dec[deg][3] RAError[mas][4] DecError[mas][5] Parallax[mas][6] Parallax_error[mas][7] PM_RA[mas/yr][8] PM_Dec[mas/year][9] PMRA_error[mas/yr][10] PMDec_error[mas/yr][11] Ref_Epoch[yr][12]",idString);
+    fprintf(out, " AstExcNoise[mas][13] AstExcNoiseSig[14] AstPriFlag[15] ");
 
-  if (!extra) {
+    if (!extra) {
+        if (print_xieta)
+            fprintf(out, " xi[deg][16] eta[deg][17] ");
+        fendl( out );
+        return;
+    }
+
+
+    fprintf(out, "phot_g_n_obs[16] phot_g_mean_flux[17] phot_g_mean_flux_error[18] phot_g_mean_flux_over_error[19] phot_g_mean_mag[20] phot_bp_n_obs[21] phot_bp_mean_flux[22] phot_bp_mean_flux_error[23] phot_bp_mean_flux_over_error[24] phot_bp_mean_mag[25] ");
+    fprintf(out, "phot_rp_n_obs[26] phot_rp_mean_flux[27] phot_rp_mean_flux_error[28] phot_rp_mean_flux_over_error[29] phot_rp_mean_mag[30] phot_bp_rp_excess_factor[31] radial_velocity[32] radial_velocity_error[33] phot_variable_flag[34] teff_val[35] teff_percentile_lower[36] ");
+    fprintf(out, "teff_percentile_upper[37] a_g_val[38] a_g_percentile_lower[39] a_g_percentile_upper[40] e_bp_min_rp_val[41] e_bp_min_rp_percentile_lower[42] e_bp_min_rp_percentile_upper[43] radius_val[44] radius_percentile_lower[45] radius_percentile_upper[46] lum_val[47] ");
+    fprintf(out, "lum_percentile_lower[48] lum_percentile_upper[49]");
+    if (print_xieta)
+        fprintf(out, " xi[deg][50] eta[deg][51]");
+
     fendl( out );
     return;
-  }
-
-
-  fprintf(out, "phot_g_n_obs[16] phot_g_mean_flux[17] phot_g_mean_flux_error[18] phot_g_mean_flux_over_error[19] phot_g_mean_mag[20] phot_bp_n_obs[21] phot_bp_mean_flux[22] phot_bp_mean_flux_error[23] phot_bp_mean_flux_over_error[24] phot_bp_mean_mag[25] ");
-  fprintf(out, "phot_rp_n_obs[26] phot_rp_mean_flux[27] phot_rp_mean_flux_error[28] phot_rp_mean_flux_over_error[29] phot_rp_mean_mag[30] phot_bp_rp_excess_factor[31] radial_velocity[32] radial_velocity_error[33] phot_variable_flag[34] teff_val[35] teff_percentile_lower[36] ");
-  fprintf(out, "teff_percentile_upper[37] a_g_val[38] a_g_percentile_lower[39] a_g_percentile_upper[40] e_bp_min_rp_val[41] e_bp_min_rp_percentile_lower[42] e_bp_min_rp_percentile_upper[43] radius_val[44] radius_percentile_lower[45] radius_percentile_upper[46] lum_val[47] ");
-  fprintf(out, "lum_percentile_lower[48] lum_percentile_upper[49]");
-  fendl( out );
-  return;
 }
 

--- a/gaialib2/gaiaPrint.c
+++ b/gaialib2/gaiaPrint.c
@@ -38,75 +38,75 @@ local void printDouble(FILE* out, double val, char* format){//format should have
 
 // default print options
 local void print_common(FILE* out, const gaiastar* star, long id,IDType type){
-  if(id==0)
-    id = star->source_id;
-  if(type==GAIA)
+  if(type==GAIA) {
+    if(id==0)
+      id = star->source_id;
     fprintf(out, "%ld",id);
+  }
   else if(type==TMASS)
     {
-      char tmassID[16];
-      char str[16];
-      sprintf(str,"%ld",id);
-      if(str[0]=='1')
-	{
-	  tmassID[0]=str[1];
-	  tmassID[1]=str[2];
-	  tmassID[2]=str[3];
-	  tmassID[3]=str[4];
-	  tmassID[4]=str[5];
-	  tmassID[5]=str[6];
-	  tmassID[6]=str[7];
-	  tmassID[7]=str[8];
-	  tmassID[8]='+';
-	  tmassID[9]=str[9];
-	  tmassID[10]=str[10];
-	  tmassID[11]=str[11];
-	  tmassID[12]=str[12];
-	  tmassID[13]=str[13];
-	  tmassID[14]=str[14];
-	  tmassID[15]=str[15];
-	}
-      else
-	{
-	  tmassID[0]=str[1];
-          tmassID[1]=str[2];
-          tmassID[2]=str[3];
-          tmassID[3]=str[4];
-          tmassID[4]=str[5];
-          tmassID[5]=str[6];
-          tmassID[6]=str[7];
-          tmassID[7]=str[8];
-          tmassID[8]='-';
-          tmassID[9]=str[9];
-          tmassID[10]=str[10];
-          tmassID[11]=str[11];
-          tmassID[12]=str[12];
-          tmassID[13]=str[13];
-          tmassID[14]=str[14];
-          tmassID[15]=str[15];
-
-	}
-      fprintf(out,"%s",tmassID);
+      if(id == 0) {
+	id = star->source_id;
+	fprintf(out, "%ld",id);
+      }
+      else {
+	char tmassID[16];
+	char str[16];
+	sprintf(str,"%ld",id);
+	if(str[0]=='1')
+	  {
+	    tmassID[0]=str[1];
+	    tmassID[1]=str[2];
+	    tmassID[2]=str[3];
+	    tmassID[3]=str[4];
+	    tmassID[4]=str[5];
+	    tmassID[5]=str[6];
+	    tmassID[6]=str[7];
+	    tmassID[7]=str[8];
+	    tmassID[8]='+';
+	    tmassID[9]=str[9];
+	    tmassID[10]=str[10];
+	    tmassID[11]=str[11];
+	    tmassID[12]=str[12];
+	    tmassID[13]=str[13];
+	    tmassID[14]=str[14];
+	    tmassID[15]=str[15];
+	  }
+	else
+	  {
+	    tmassID[0]=str[1];
+	    tmassID[1]=str[2];
+	    tmassID[2]=str[3];
+	    tmassID[3]=str[4];
+	    tmassID[4]=str[5];
+	    tmassID[5]=str[6];
+	    tmassID[6]=str[7];
+	    tmassID[7]=str[8];
+	    tmassID[8]='-';
+	    tmassID[9]=str[9];
+	    tmassID[10]=str[10];
+	    tmassID[11]=str[11];
+	    tmassID[12]=str[12];
+	    tmassID[13]=str[13];
+	    tmassID[14]=str[14];
+	    tmassID[15]=str[15];
+	    
+	  }
+	fprintf(out,"%s",tmassID);
+      }
 
     }
   else if(type==HAT)
     {
-      char hatID[20];
-      char str[20];
-      sprintf(str,"%ld",id);
-      hatID[0]=str[strlen(str)-3];
-      hatID[1]=str[strlen(str)-2];
-      hatID[2]=str[strlen(str)-1];
-      hatID[3]='-';
-
-      unsigned int i;
-      for(i = 0; i<strlen(str)-3;i++)
-	{
-	  hatID[4+i]=str[i];
-	}
-      hatID[i+4]='\0';
-      fprintf(out,"%s",hatID);
-      
+      if(id == 0) {
+	id = star->source_id;
+	fprintf(out, "%ld",id);
+      }
+      else {
+	char hatID[20];
+	sprintf(hatID,"%03d-%07d",((int) (id % 1000)),((int) (id / 1000)));
+	fprintf(out,"%s",hatID);
+      }
     }
   printDouble(out,star->ra," %14.10f");
   printDouble(out,star->dec," %14.10f");
@@ -212,11 +212,11 @@ void gaiastar_printlist_alternateID(FILE* out, const gaiastar stars[], bool extr
       const gaiastar* star = &stars[i];
       const long* id = (const long*)ids->data;
       if (type==TMASS && *id!=0)
-	fprintf(out,"2MASS ");
+	fprintf(out,"2MASS-");
       else if(type==HAT && *id!=0)
-	fprintf(out,"HAT ");
+	fprintf(out,"HAT-");
       else
-	fprintf(out,"GAIA ");
+	fprintf(out,"GAIA-");
 
       gaiastar_printextra(out, star, *id,type);
       ids = ids->next;
@@ -228,11 +228,11 @@ void gaiastar_printlist_alternateID(FILE* out, const gaiastar stars[], bool extr
       const gaiastar* star = &stars[i];
       const long* id = (const long*)ids->data;
       if (type==TMASS && *id!=0)
-        fprintf(out,"2MASS ");
+        fprintf(out,"2MASS-");
       else if(type==HAT && *id!=0)
-	fprintf(out,"HAT ");
+	fprintf(out,"HAT-");
       else
-	fprintf(out,"GAIA ");
+	fprintf(out,"GAIA-");
 
       gaiastar_print(out, star, *id,type);
       ids = ids->next;
@@ -245,14 +245,14 @@ void gaiastar_printheader(FILE* out, bool extra, IDType outType)
 {
   char *idString;
   if (outType == GAIA)
-    idString = "Gaia";
+    idString = "Gaia-";
   else if (outType == HAT)
-    idString = "HAT";
+    idString = "HAT-";
   else
-    idString = "2MASS";
+    idString = "2MASS-";
 
   // ID and position                                                                                                                                                                                                                                                            
-  fprintf(out, "%s ID[1] RA[deg][2] Dec[deg][3] RAError[mas][4] DecError[mas][5] Parallax[mas][6] Parallax_error[mas][7] PM_RA[mas/yr][8] PM_Dec[mas/year][9] PMRA_error[mas/yr][10] PMDec_error[mas/yr][11] Ref_Epoch[yr][12]",idString);
+  fprintf(out, "#%sID[1] RA[deg][2] Dec[deg][3] RAError[mas][4] DecError[mas][5] Parallax[mas][6] Parallax_error[mas][7] PM_RA[mas/yr][8] PM_Dec[mas/year][9] PMRA_error[mas/yr][10] PMDec_error[mas/yr][11] Ref_Epoch[yr][12]",idString);
   fprintf(out, " AstExcNoise[mas][13] AstExcNoiseSig[14] AstPriFlag[15] ");
 
   if (!extra) {
@@ -265,5 +265,7 @@ void gaiastar_printheader(FILE* out, bool extra, IDType outType)
   fprintf(out, "phot_rp_n_obs[26] phot_rp_mean_flux[27] phot_rp_mean_flux_error[28] phot_rp_mean_flux_over_error[29] phot_rp_mean_mag[30] phot_bp_rp_excess_factor[31] radial_velocity[32] radial_velocity_error[33] phot_variable_flag[34] teff_val[35] teff_percentile_lower[36] ");
   fprintf(out, "teff_percentile_upper[37] a_g_val[38] a_g_percentile_lower[39] a_g_percentile_upper[40] e_bp_min_rp_val[41] e_bp_min_rp_percentile_lower[42] e_bp_min_rp_percentile_upper[43] radius_val[44] radius_percentile_lower[45] radius_percentile_upper[46] lum_val[47] ");
   fprintf(out, "lum_percentile_lower[48] lum_percentile_upper[49]");
+  fendl( out );
+  return;
 }
 

--- a/gaialib2/gaiaPrint.h
+++ b/gaialib2/gaiaPrint.h
@@ -2,13 +2,14 @@
 
 #include "gaia2ret.h"
 #include "sllist.h"
+#include "astrometry.h"
 
 // print list of stars with Gaia ID
-void gaiastar_printlist(FILE* out,const gaiastar stars[], bool extra,int count);
+void gaiastar_printlist(FILE* out, const gaiastar stars[], int count, bool extra, skypos* xieta_center);
 
 // print list of stars with specified ID type
-void gaiastar_printlist_alternateID(FILE* out, const gaiastar stars[], bool extra, const sllist* alternateIDs, IDType type,int count);
+void gaiastar_printlist_alternateID(FILE* out, const gaiastar stars[], int count, bool extra, const sllist* alternateIDs, IDType type, skypos* xieta_center);
 
 // print header
-void gaiastar_printheader(FILE* out, bool extra, IDType outType);
+void gaiastar_printheader(FILE* out, bool extra, IDType outType, bool print_xieta);
 

--- a/gaialib2/gaiastar.h
+++ b/gaialib2/gaiastar.h
@@ -7,7 +7,7 @@
 
 typedef struct
 {
-  // This data is the default show                                                                                                                                                                                                                                              
+  // This data is the default show
   long source_id;
   double ref_epoch;
   double ra;
@@ -23,9 +23,9 @@ typedef struct
   double astrometric_excess_noise;
   double astrometric_excess_noise_sig;
   bool astrometric_primary_flag;
-  //109 bytes                                                                                                                                                                                                                                                                   
+  //109 bytes
 
-  // This data below is optional                                                                                                                                                                                                                                                
+  // This data below is optional
   int phot_g_n_obs;
   double phot_g_mean_flux;
   double phot_g_mean_flux_error;

--- a/gaialib2/tmassIDsort.c
+++ b/gaialib2/tmassIDsort.c
@@ -1,0 +1,137 @@
+#include "utils.h"
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+char * strsep(char **stringp, const char *delim);
+
+typedef struct
+{
+  long tmass;
+  long hat;
+
+}ID2;
+
+int idcmp(const void * a, const void * b)
+{
+  ID2* id1 = (ID2*)a;
+  ID2* id2 = (ID2*)b;
+  long result =  id1->tmass - id2->tmass;
+  if (result<0)
+    return -1;
+  if (result>0)
+    return 1;
+  return 0;
+}
+
+// string concatenation
+/*char *concat(const char *s1, const char *s2)
+{
+  char *result;
+
+  result = malloc(strlen(s1) + strlen(s2) + 1);
+  if (result == NULL)
+    {
+      printf("Error: malloc failed in concat\n");
+      exit(EXIT_FAILURE);
+    }
+  strcpy(result, s1);
+  strcat(result, s2);
+  return result;
+  }*/
+
+int main(void)
+{
+  char* catpath = "/home/jkim/catalogs/H-CAT/2MASS/2MASS_JH_AP/data/hat2masskeys/";
+  long starCount = 0;
+  ID2 *idArray = malloc(470992970*sizeof(ID2));
+  //ID2 *idArray = malloc(153143*sizeof(ID2));
+  int index = 0;
+  for (int i = 1; i < 839; i++)
+    {
+      //      if( i!=15)
+      //	continue;
+      char* fileName;
+      char* buffer;
+      char temp[4];
+      if (i < 10)
+	{
+	  sprintf(temp,"%d",i);
+	  buffer = concat("00",temp);
+	  fileName = concat(concat(catpath,buffer),".txt");
+	}
+      else if(i < 100)
+	{
+	  sprintf(temp,"%d",i);
+	  buffer = concat("0",temp);
+	  fileName = concat(concat(catpath,buffer),".txt");
+	}
+      else
+	{
+	  sprintf(buffer,"%d",i);
+	  fileName = concat(concat(catpath,buffer),".txt");
+	}
+      FILE *file = fopen(fileName,"r");
+      if ( file == NULL )
+        {
+	  printf("error: could not open file\n");
+        }
+      printf("%s\n",fileName);
+
+      char line[20];
+      long lineCount = 1;
+        while(fgets(line, 20, file) != NULL)
+	  {
+	    //	    printf("%s\n",line);
+	    //	  starCount++;
+	    char firstHalf[9];
+	    memcpy(firstHalf,line,8);
+	    char secondHalf[8];
+	    memcpy(secondHalf,&line[9],7);
+	    
+	    char* tmassString;
+	    if (line[8]=='+')
+	      {
+		tmassString = concat(concat("1",firstHalf),secondHalf);
+	      }
+	    else
+	      {
+		tmassString = concat(concat("2",firstHalf),secondHalf);
+	      }
+	    char hatFirstHalf[8];
+	    sprintf(hatFirstHalf,"%ld",lineCount);
+	    char * hatString = concat(hatFirstHalf,buffer);
+	    lineCount++;
+
+	    long tmass;
+	    long hatID;
+	    
+	    tmass=strtol(tmassString,NULL,10);
+	    hatID=strtol(hatString,NULL,10);
+
+
+	    //      	  printf("%ld %ld\n",tmass,hatID);
+	    ID2 nextID;
+	    nextID.tmass=tmass;
+	    nextID.hat=hatID;
+	  idArray[index] = nextID;
+	  //	  printf("%ld %ld\n",idArray[index].tmass,idArray[index].hat);
+      	  index++;
+	  starCount++;
+	  }
+    }
+  printf("%ld",starCount);
+  printf("sorting...\n");
+  qsort(idArray,470992970,sizeof(ID2),idcmp);
+  //  qsort(idArray,153143,sizeof(ID2),idcmp);
+  /*for (int i = 0; i < 153143; i++)
+   {
+     printf("%ld %ld\n",idArray[i].tmass,idArray[i].hat);
+   }*/
+  printf("writing...\n");
+  FILE *outFile = fopen("/home/jkim/work/Gaia2Mass/hat2mass","wb");
+  fwrite(idArray,sizeof(ID2),470992970,outFile);
+  fclose(outFile);
+  printf("done\n");
+  return 0;
+}


### PR DESCRIPTION
- Allow filtering by G, Rp, Bp magnitude cuts down number of stars to cross-match and print.
- During ID cross-matching, use mmap to load file into memory instead of performing repeated fseeks.
- Add option to output xi/eta frame-projected coordinates centered at given sky position.